### PR TITLE
Emit pre-init `match_starting` notification for BR queues and handle it client-side

### DIFF
--- a/frontend/game/multiplayer/client/MultiplayerMessageController.js
+++ b/frontend/game/multiplayer/client/MultiplayerMessageController.js
@@ -32,6 +32,10 @@ export class MultiplayerMessageController {
             case SERVER_EVENTS.STATE:
                 this.effectsController.handleState(msg);
                 break;
+
+            case SERVER_EVENTS.MATCH_STARTING:
+                this.effectsController.handleMatchStarting(msg);
+                break;
             
             // Battle Royale: Cross-dungeon events
             case SERVER_EVENTS.PLAYER_LEFT_VIA_TUNNEL:

--- a/frontend/game/multiplayer/client/MultiplayerMessageEffectsController.js
+++ b/frontend/game/multiplayer/client/MultiplayerMessageEffectsController.js
@@ -75,6 +75,7 @@ export class MultiplayerMessageEffectsController {
     }
 
     handleInit(msg) {
+        this._clearMatchStartingStatus();
         if (typeof this.setIsConnecting === 'function') this.setIsConnecting(false);
         if (typeof this.setHasJoinedGame === 'function') this.setHasJoinedGame(true);
         this.uiController.setButtonState(false);
@@ -95,6 +96,19 @@ export class MultiplayerMessageEffectsController {
                 dungeonId: this.session.dungeonId,
             });
         }
+    }
+
+    handleMatchStarting(msg) {
+        const message = msg?.message || 'Match found, launching…';
+        this.uiController.setStatus(message);
+        this.uiController.setStatusError(false);
+
+        const ttl = Number(msg?.expires_ms) || 4000;
+        this._clearMatchStartingStatusTimer();
+        this._matchStartingStatusTimer = setTimeout(() => {
+            this.uiController.setStatus('');
+            this._matchStartingStatusTimer = null;
+        }, ttl);
     }
 
     handleState(msg) {
@@ -313,5 +327,17 @@ export class MultiplayerMessageEffectsController {
                 body: JSON.stringify({ user_id: userId, score }),
             }).catch(() => { /* best-effort */ });
         } catch (_) { /* ignore */ }
+    }
+
+    _clearMatchStartingStatus() {
+        this._clearMatchStartingStatusTimer();
+        this.uiController.setStatus('');
+    }
+
+    _clearMatchStartingStatusTimer() {
+        if (this._matchStartingStatusTimer) {
+            clearTimeout(this._matchStartingStatusTimer);
+            this._matchStartingStatusTimer = null;
+        }
     }
 }

--- a/frontend/game/multiplayer/client/multiplayerEvents.js
+++ b/frontend/game/multiplayer/client/multiplayerEvents.js
@@ -22,6 +22,7 @@ export const SERVER_EVENTS = Object.freeze({
     // Battle Royale: Queue status
     SITNGO_QUEUE_STATUS: 'sitngo_queue_status',
     TEAM_QUEUE_STATUS: 'team_queue_status',
+    MATCH_STARTING: 'match_starting',
     // Match lifecycle
     MATCH_END: 'match_end',
 });

--- a/frontend/game/multiplayer/server/SitNGoQueue.js
+++ b/frontend/game/multiplayer/server/SitNGoQueue.js
@@ -16,6 +16,7 @@
 const MIN_PLAYERS = 2;  // Minimum to start countdown
 const MAX_PLAYERS = 8;  // Maximum before instant start
 const COUNTDOWN_MS = 15000;  // 15 seconds after MIN_PLAYERS
+const MATCH_STARTING_EVENT = 'match_starting';
 
 class SitNGoQueue {
     constructor(gameServer) {
@@ -126,6 +127,8 @@ class SitNGoQueue {
         
         const ServerPlayer = require('./ServerPlayer').ServerPlayer;
         const players = Array.from(this.waitingPlayers.entries());
+
+        this._notifyMatchStarting();
         
         // Create dungeon for each player
         players.forEach(([playerId, { conn }], index) => {
@@ -157,6 +160,18 @@ class SitNGoQueue {
         this.waitingPlayers.clear();
         
         console.log('[SitNGoQueue] Game launched successfully');
+    }
+
+    _notifyMatchStarting() {
+        const payload = {
+            type: MATCH_STARTING_EVENT,
+            message: 'Match found, launching…',
+            expires_ms: 4000,
+        };
+
+        for (const { conn } of this.waitingPlayers.values()) {
+            this.gameServer._send(conn.ws, payload);
+        }
     }
 
     launchWithBots() {

--- a/frontend/game/multiplayer/server/TeamBRQueue.js
+++ b/frontend/game/multiplayer/server/TeamBRQueue.js
@@ -17,6 +17,7 @@
 
 const MIN_TEAMS_SITNGO = 2;
 const COUNTDOWN_MS = 20000;  // 20 seconds for team mode
+const MATCH_STARTING_EVENT = 'match_starting';
 
 class TeamBRQueue {
     constructor(gameServer, mode = 'team-endless') {
@@ -95,6 +96,8 @@ class TeamBRQueue {
         // Start game
         dungeon.startGame();
         
+        this._sendMatchStarting(conn);
+
         // Send init
         this.gameServer._sendInit(conn, dungeon);
         
@@ -175,6 +178,7 @@ class TeamBRQueue {
         }
         
         const ServerPlayer = require('./ServerPlayer').ServerPlayer;
+        this._notifyMatchStarting();
         
         // Form teams of 2
         for (let i = 0; i < players.length; i += 2) {
@@ -226,6 +230,26 @@ class TeamBRQueue {
         this.waitingPlayers.clear();
         
         console.log('[TeamBRQueue] Team game launched');
+    }
+
+    _notifyMatchStarting() {
+        const payload = {
+            type: MATCH_STARTING_EVENT,
+            message: 'Match found, launching…',
+            expires_ms: 4000,
+        };
+
+        for (const { conn } of this.waitingPlayers.values()) {
+            this.gameServer._send(conn.ws, payload);
+        }
+    }
+
+    _sendMatchStarting(conn) {
+        this.gameServer._send(conn.ws, {
+            type: MATCH_STARTING_EVENT,
+            message: 'Match found, launching…',
+            expires_ms: 4000,
+        });
     }
     
     /**


### PR DESCRIPTION
### Motivation
- Players in BR queues should receive a short-lived pre-init notice when a match is found so the client can show a "Match found, launching…" message before `init` arrives. 
- Implement this additively so the existing `init`/`state` protocol remains fully backward compatible.

### Description
- Server: added a `MATCH_STARTING_EVENT` constant and a `_notifyMatchStarting()` helper in `SitNGoQueue` and `TeamBRQueue`, and call it immediately before sending `init` so all queued participants receive a `match_starting` payload. (`frontend/game/multiplayer/server/SitNGoQueue.js`, `frontend/game/multiplayer/server/TeamBRQueue.js`).
- Server: for instant team starts (`team-endless`) send a per-connection `match_starting` message via `_sendMatchStarting(conn)` before `init`. (`frontend/game/multiplayer/server/TeamBRQueue.js`).
- Client: added `MATCH_STARTING` to `SERVER_EVENTS` in `multiplayerEvents.js` and routed the event in `MultiplayerMessageController` to a new handler. (`frontend/game/multiplayer/client/multiplayerEvents.js`, `frontend/game/multiplayer/client/MultiplayerMessageController.js`).
- Client UI: implemented `handleMatchStarting` in `MultiplayerMessageEffectsController` to render a temporary status (`Match found, launching…`), clear it after the server TTL, and explicitly clear any pending match-starting status when `init` arrives to preserve compatibility. (`frontend/game/multiplayer/client/MultiplayerMessageEffectsController.js`).

### Testing
- Ran syntax checks with `node --check frontend/game/multiplayer/server/SitNGoQueue.js` and it succeeded. 
- Ran syntax checks with `node --check frontend/game/multiplayer/server/TeamBRQueue.js` and it succeeded. 
- Ran syntax checks with `node --check frontend/game/multiplayer/client/multiplayerEvents.js` and it succeeded. 
- Ran syntax checks with `node --check frontend/game/multiplayer/client/MultiplayerMessageController.js` and `node --check frontend/game/multiplayer/client/MultiplayerMessageEffectsController.js` and both succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9bab3f6d0832ebfb06fda54e4fe8e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added match-starting notification system that displays "Match found, launching..." to players when a match is found, with automatic status clearing after the launch phase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->