### PR TITLE
Expand multiplayer button disable coverage for BR mode buttons

### DIFF
--- a/frontend/game/multiplayer/client/MultiplayerSessionController.js
+++ b/frontend/game/multiplayer/client/MultiplayerSessionController.js
@@ -63,7 +63,7 @@ export class MultiplayerSessionController {
 
     handleSocketClose() {
         this._isConnecting = false;
-        this.uiController.setButtonState(false);
+        this.uiController.setButtonState(!this._hasJoinedGame);
         this.uiController.toggleRetry(!!this._lastJoinType);
         this.uiController.setStatus(this._hasJoinedGame
             ? 'Disconnected from server. Retry to reconnect.'
@@ -73,6 +73,8 @@ export class MultiplayerSessionController {
     }
 
     handleSocketError() {
+        this._isConnecting = false;
+        this.uiController.setButtonState(!this._hasJoinedGame);
         this.uiController.setStatus('Connection error — check server status and try again.');
         this.uiController.setStatusError(true);
     }

--- a/frontend/game/multiplayer/client/MultiplayerUiController.js
+++ b/frontend/game/multiplayer/client/MultiplayerUiController.js
@@ -12,7 +12,14 @@ export class MultiplayerUiController {
     }
 
     setButtonState(disabled) {
-        const ids = ['btnPairCreate', 'btnPairJoin'];
+        const ids = [
+            'btnSolo',
+            'btnSitNGo',
+            'btnTeamBr',
+            'btnTeamSitNGo',
+            'btnPairCreate',
+            'btnPairJoin',
+        ];
         for (const id of ids) {
             const el = document.getElementById(id);
             if (el) el.disabled = !!disabled;


### PR DESCRIPTION
### Motivation
- Public BR mode buttons were not being disabled during connection flows, leading to possible duplicate attempts; the UI should mirror the private-pair buttons' disable behavior and respect session state.

### Description
- Added `btnSolo`, `btnSitNGo`, `btnTeamBr`, and `btnTeamSitNGo` to `MultiplayerUiController.setButtonState(disabled)` while keeping `btnPairCreate` and `btnPairJoin` unchanged.
- Updated `MultiplayerSessionController.handleSocketClose()` and `handleSocketError()` to call `setButtonState(!this._hasJoinedGame)` so buttons are re-enabled only when the session has not already joined a game.
- Ensured `connect()` remains the single place that disables buttons and that failed connects still re-enable them by preserving the existing `didConnect` handling.

### Testing
- Ran syntax checks: `node --check frontend/game/multiplayer/client/MultiplayerUiController.js` and `node --check frontend/game/multiplayer/client/MultiplayerSessionController.js`, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9baa84928832e8cf1d370e36497fc)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved responsiveness of game mode buttons during socket connection interruptions and errors
  * Extended button state management to all available game mode selection options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->